### PR TITLE
fix: :bug: Change str_replace to dirname

### DIFF
--- a/app/models/Database.php
+++ b/app/models/Database.php
@@ -8,7 +8,7 @@ class Database extends Model {
     public function __construct(){
         $dbFile = 'config/database.json';
 
-        $this->fullPath = str_replace("app/models/Database.php", $dbFile, __FILE__);
+        $this->fullPath = dirname(__DIR__, 2) . '/config/database.json';
 
         if(file_exists($this->fullPath)){
             $data = file_get_contents($this->fullPath);


### PR DESCRIPTION
The issue with:

```
str_replace("app/models/Database.php", $dbFile, __FILE__);
```
was that if the `__FILE__` path did not match the string provided exactly, the replacement would not work. This occurred due to the differences in path separators between MacOS (/) and Windows (\). As a result, str_replace failed, causing an error when trying to construct the file path.

The solution:

```
$this->fullPath = dirname(__DIR__, 2) . '/config/database.json';
```

uses dirname(`__DIR__`, 2) to move up two directory levels, forming the path in a way that is independent of the operating system. This ensures that the path construction works correctly on both Windows and MacOS/Linux by consistently concatenating the path string with the desired file.

