### PR TITLE
refactor: :truck: Suggestion: add routing for '/' instead of '/home'.

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -11,7 +11,7 @@
  */
 $routes = array(
 	'/test' => 'test#index',
-	'/home'=> 'view#index',
+	'/'=> 'view#index',
 	'/view'=> 'view#index',
 	'/view/:id'=> 'view#task',
 	'/create'=> 'create#create',


### PR DESCRIPTION
After giving some thought to this, maybe we could leave routes to main view as `/`. 
I suggest replacing `/home` for `/`. 

I doubt about removing `/view` as well because I think it keeps coherence with other paths. It would be weird to use `/:id` instead of `view/:id` right?